### PR TITLE
feature: update eslint dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,23 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   ci:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         id: npm-cache
         with:
           path: '**/node_modules'
@@ -37,17 +41,17 @@ jobs:
         env:
           PATH_PREFIX: /theme-noctis-uva
       - name: Upload artifact
-        if: matrix.os == 'ubuntu-22.04'
-        uses: actions/upload-pages-artifact@v4
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: ci
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,15 +9,15 @@ jobs:
   pr:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         id: npm-cache
         with:
           path: '**/node_modules'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   create-release:
     name: create-release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       upload_url: ${{ steps.release.outputs.upload_url }}
       rg_version: ${{ env.RG_VERSION }}
@@ -32,14 +32,14 @@ jobs:
   build-release:
     name: build-release
     needs: ['create-release']
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         id: npm-cache
         with:
           path: '**/node_modules'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^16.4.0",
+        "@lvce-editor/eslint-config": "^17.5.0",
         "@lvce-editor/package-extension": "^3.2.0",
         "@lvce-editor/server": "^0.70.20",
-        "eslint": "^10.7.0"
+        "eslint": "^10.8.0",
+        "prettier": "^3.9.6"
       }
     },
     "node_modules/@altano/repository-tools": {
@@ -1215,9 +1216,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1526,11 +1527,14 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.4.0.tgz",
-      "integrity": "sha512-vc382ImEo+upv9LR+kr0vSpfyV8BBxKb+m2nCBVXjGm7eu5Cw9zTPv9X+mxOjWiNkUyWfuwY+NgbgsSC4Scu8g==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.5.0.tgz",
+      "integrity": "sha512-wjDaVd24PNVZdjbV8EcQYrbEWsKAJ9mak03EUIMTT6+tHVwlg9G1P2eDvqpxyMSmY3ywBKhAPigEjY2pwnCGUQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@cspell/eslint-plugin": "10.0.1",
         "@e18e/eslint-plugin": "^0.5.1",
@@ -1538,14 +1542,15 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.4.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.4.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.4.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.4.0",
-        "@lvce-editor/eslint-plugin-regex": "16.4.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.4.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.4.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.4.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.5.0",
+        "@lvce-editor/eslint-plugin-e2e": "17.5.0",
+        "@lvce-editor/eslint-plugin-extension-json": "17.5.0",
+        "@lvce-editor/eslint-plugin-github-actions": "17.5.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.5.0",
+        "@lvce-editor/eslint-plugin-regex": "17.5.0",
+        "@lvce-editor/eslint-plugin-rpc": "17.5.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.5.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.5.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -1560,9 +1565,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.4.0.tgz",
-      "integrity": "sha512-KWAhBTB5GZrgFoL16rYvY6QI+MHUd5kQ++uFWpV8WE2/pF4RI2xiOTft7lfWUD+EARG9ygyRFbgtVO0RFlFOQw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.5.0.tgz",
+      "integrity": "sha512-wNemW3CGngT/bRzB2ldVWW5++V/Xq549Hkbf7ZCc00XGxJhupZKTAYL3qCQvpdT5OJTUFc58Z9ddg42OLVENiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1570,16 +1575,26 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.4.0.tgz",
-      "integrity": "sha512-kS1IGkvUeOZeVUGs+fxSOzGqqXRwWL1dZq1Kq0KHo24gNZ/WqKi2cLVWpAAyQZA+P0dp82SG7WwZ+NZHhPYoSA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.5.0.tgz",
+      "integrity": "sha512-xGWeOY+aitgaKgxCVeRSJfEWMLf39u5wnq0uA3ZnZKFWXEHpZO3CaJi+9rw7KgFK7TcqgpxsaAHTENYEoabJHQ==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/eslint-plugin-extension-json": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.5.0.tgz",
+      "integrity": "sha512-F7qOAYW1LhFntc2f5Yn1QQqArqgVLi1tW6vRNzgWIptlrZTib0cGFG4jKOL7ZgB5uDl0mZWlZ9q1Q1T055eWhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-16.4.0.tgz",
-      "integrity": "sha512-T66LFDS0nX3/H5nxFiNIkUMEou55FlOxLgOfkbCivZdQQ+fTZnNYb1zOdkxk9hKzQC6RaO4Oj0soilT02TDOQQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.5.0.tgz",
+      "integrity": "sha512-RhphHPbVQHqRu2yAZ/XnUdpP67BbPrIIrAvdkqSnitCVu65DDTTN1YVZMNdNv8cYue8V3V8eUMIf8WaNFBdJEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1588,9 +1603,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.4.0.tgz",
-      "integrity": "sha512-/vx42EiKdt8E7oJ+pbTTKC+V9tgO7yiLKnHlXi664A/s4rEQOfJbB9wq4HYY2hmsDymGokKcNCJNOrdE8GwszA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.5.0.tgz",
+      "integrity": "sha512-mYcLlKt8Y2wKlM13xFXKaYDvKDOj/O5nnfj51oW7UTItROxtlD848eaXcxpLrH5iLTW5wC3G3Oz9ftwoGmqq7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1611,23 +1626,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.4.0.tgz",
-      "integrity": "sha512-XOVlNT6inumz2GLe70A5yuqRvEhGtXe2aCwtCuAnbkD5d1HH5G5NwSA374sF6Z+Kiy02s23eVfxOk+0oh2yQ6g==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.5.0.tgz",
+      "integrity": "sha512-PER04Hz35vvDFWXPK9wkSyAXB/H5aGGPE6i8nesbmGUP43fqT+7f9Kf5wzRUbUOdZ8HuFcnVQZALMbaEe1NcSg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.4.0.tgz",
-      "integrity": "sha512-ghI9uGpUyxPnJnVgKojf0RWTxGnNdmPz/JS4GdvHhw+Kl0cC2OQmvOKLDTSV423hj4WjaUBDqfdeAIZVMq0vLg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.5.0.tgz",
+      "integrity": "sha512-7dfk74/7pFDK2fWnDK1M8OP46ehlMiK2TlOZYvsg3kU0J4dC0m7emnwvWKCgzyd/rNVPsTyqcz8PSM3U+4Lf4Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-16.4.0.tgz",
-      "integrity": "sha512-tVzMUV7vVy3H6M5kCgDxnL8EXRvDic0+GUb6fmzdsemU/HkA+zlKDbvKs9bfI79hX3EWeptFN2GOXnrGB84MbQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.5.0.tgz",
+      "integrity": "sha512-505lmJeM12Bq5eTZ5FMjB7qmbSu0Xi8bjVCbBSjyMNAVhCAiEUfuWXq0TeiJFeT40GzF88On0GPYHxS+dviWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1635,9 +1650,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.4.0.tgz",
-      "integrity": "sha512-h0QVBtyzs0/ICLIDBDB1DFzmdvyCHfJB/AFxaonFJ7f6PIrUEFz/HjxvX8jMhcCllRxUrslWqF6DC9Gs76isVw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.5.0.tgz",
+      "integrity": "sha512-sGiPawCOnR4E/8Bb+NTLlPpmvYS/t2vYrPwoG9/KVUq6gRnj3M34pQw2vsxP9A+PYig5LeL9TX5Wjj//DYVpXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4280,9 +4295,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -4292,7 +4307,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -4316,7 +4331,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -7807,6 +7822,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   "author": "Lvce Editor",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^16.4.0",
+    "@lvce-editor/eslint-config": "^17.5.0",
     "@lvce-editor/package-extension": "^3.2.0",
     "@lvce-editor/server": "^0.70.20",
-    "eslint": "^10.7.0"
+    "eslint": "^10.8.0",
+    "prettier": "^3.9.6"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Update `eslint` and `@lvce-editor/eslint-config` to their latest versions.

The newer shared rules require supported runner/action versions and GitHub Pages concurrency, so the workflows are updated accordingly. The lint script already invokes Prettier, which is now declared directly instead of relying on a transitive dependency.

Validation:
- `npm run lint`
- `node scripts/build-static.js`
- `node scripts/build.js`