### PR TITLE
feature: add keyword operator color

### DIFF
--- a/color-theme.json
+++ b/color-theme.json
@@ -116,6 +116,10 @@
       "foreground": "#DF769B"
     },
     {
+      "name": "KeywordOperator",
+      "foreground": "#DF769B"
+    },
+    {
       "name": "Numeric",
       "foreground": "#7060EB"
     },


### PR DESCRIPTION
Adds a `KeywordOperator` color aligned with the theme's syntax palette, including Elm's `not` operator.